### PR TITLE
Add additional path for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # Node
 /node_modules
+/express-backend/node_modules
 npm-debug.log
 yarn-error.log
 


### PR DESCRIPTION
Exclude node_modules in the new express-backend directory from git as well.